### PR TITLE
More initiative fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ The project is free and open source, but if you'd like to contribute financially
 
 ## Change Log
 
+### [1.0.2] - 2022-08-05
+
+- Fixed an issue where players were seeing permission errors at start of combat
+- Should now correctly reset the current active turn after initiative rolls at the top of a new round.
+
+### [1.0.1] - 2022-05-23
+
+- Fixed an issue with fumble rolls
+
 ### [1.0.0] - 2022-05-21
 
 - Attacks that use charges can now be linked to powers that have them as long as both are owned by the same character - so now charges can be auto-deducted when the attack is rolled.

--- a/macro-helpers.md
+++ b/macro-helpers.md
@@ -27,11 +27,9 @@ Examples:
 
 
 ## RollOtherMacro
-A miscellaneous catch-all for other common types of rolls.  (Note that luck has been included here as well, since it's not really a save.  Calling Luck from this function )
+A miscellaneous catch-all for other common types of rolls.
 
 Examples:
-
-`game.mp.rollOtherMacro("Luck");`
 
 `game.mp.rollOtherMacro("Mass");`
 

--- a/module/mpcombat.js
+++ b/module/mpcombat.js
@@ -11,9 +11,25 @@ export default class MPCombat extends Combat {
 
     async rollInitiative(ids, options) {
         if (!options) {
-            options = {};
+            options = {updateTurn: false};
         }
-        setProperty(options, "updateTurn", false);
+        
         await super.rollInitiative(ids, options);
+        return this.update({ turn: 0 });
     }
+
+    setupTurns() {
+        console.warn(this.combatants);
+        const turns = this.combatants.contents.sort(this._sortCombatants);
+
+        console.warn(turns);
+   
+        this.current = {
+          round: this.data.round,
+          turn: 0,
+        }
+    
+        return this.turns = turns;
+      }
+
 }

--- a/module/mpcombatant.js
+++ b/module/mpcombatant.js
@@ -13,8 +13,10 @@ export default class MPCombatant extends Combatant {
              actor = token.actor;
          }
 
-         multiInit = actor.data.data.multiinit;
-         this.setFlag("mighty-protectors", "hasMulti", multiInit);   
+         if (this.isOwner) {
+            multiInit = actor.data.data.multiinit;
+            this.setFlag("mighty-protectors", "hasMulti", multiInit);
+         }   
     }
 
 

--- a/system.json
+++ b/system.json
@@ -7,7 +7,7 @@
   "url": "https://github.com/drl2/mighty-protectors-fvtt",
   "license": "LICENSE.txt",
   "flags": {},
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minimumCoreVersion": "0.8.0",
   "compatibleCoreVersion": "9",
   "scripts": [],


### PR DESCRIPTION
### [1.0.2] - 2022-08-05

- Fixed an issue where players were seeing permission errors at start of combat
- Should now correctly reset the current active turn after initiative rolls at the top of a new round.